### PR TITLE
Incompatibility with Python3.8

### DIFF
--- a/src/drools/ruleset.py
+++ b/src/drools/ruleset.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import ClassVar
+from typing import ClassVar, Dict
 
 import jpyutil
 
@@ -123,7 +123,7 @@ class Ruleset:
 
 @dataclass
 class RulesetCollection:
-    __cached_objects: ClassVar[dict[str, Rule]] = {}
+    __cached_objects: ClassVar[Dict[str, Ruleset]] = {}
 
     @classmethod
     def add(cls, ruleset: Ruleset):


### PR DESCRIPTION
The ClassVar dict wasn't supported in 3.8
It should be ClassVar Dict
https://issues.redhat.com/browse/AAP-6326