### PR TITLE
Added support for testing with python 3.8

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,14 +57,16 @@ drools_jpy = ["*.jar"]
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = py39,py310
+envlist = py38,py39,py310
 
 [gh-actions]
 python =
+    3.8: py38
     3.9: py39
     3.10: py310
 
 [testenv]
+passenv = JAVA_HOME
 deps = pytest               # PYPI package providing pytest,
        jpy
        tox-wheel


### PR DESCRIPTION
Since we need to support Python 3.8 run tox with python 3.8 For some reason tox doesn't pass the JAVA_HOME env var to the test env unless its in the passenv